### PR TITLE
english pages

### DIFF
--- a/csplainnat.bst
+++ b/csplainnat.bst
@@ -550,8 +550,8 @@ FUNCTION {format.pages}
 { pages empty$
     { "" }
     { pages multi.page.check
-        { "s." pages n.dashify tie.or.space.connect }  % CHANGE mudrd8mz 2007-03-15: 'pages' -> 's.'
-        { "s." pages tie.or.space.connect }            % CHANGE mudrd8mz 2007-03-15: 'pages' -> 's.'
+        { "pp." pages n.dashify tie.or.space.connect }  % CHANGE mudrd8mz 2007-03-15: 'pages' -> 'pp.'
+        { "p." pages tie.or.space.connect }            % CHANGE mudrd8mz 2007-03-15: 'pages' -> 'p.'
       if$
     }
   if$


### PR DESCRIPTION
`p.` for one page, `pp.` for page range - according to [stackexchange](http://english.stackexchange.com/questions/14533/usage-of-p-versus-pp-versus-pg-to-denote-page-numbers-and-page-ranges)
